### PR TITLE
Demo of <script lang="coffee">

### DIFF
--- a/.meteor/versions
+++ b/.meteor/versions
@@ -2,7 +2,7 @@ accounts-base@1.3.1
 accounts-password@1.4.0
 akryum:npm-check@0.0.3
 akryum:vue-coffee@0.0.5
-akryum:vue-component@0.10.5
+akryum:vue-component@0.10.6
 akryum:vue-component-dev-client@0.2.12
 akryum:vue-component-dev-server@0.0.10
 akryum:vue-less@0.0.5
@@ -25,7 +25,8 @@ caching-html-compiler@1.1.2
 callback-hook@1.0.10
 check@1.2.5
 chuangbo:cookie@1.1.0
-coffeescript@1.12.6_1
+coffeescript@1.12.7_1
+coffeescript-compiler@1.12.7_1
 cosmos:browserify@0.10.0
 ddp@1.3.0
 ddp-client@2.0.0

--- a/src/imports/ui/GoogleMap.vue
+++ b/src/imports/ui/GoogleMap.vue
@@ -19,24 +19,21 @@
   </div>
 </template>
 
-<script>
-export default {
-  data () {
-    return {
-      description: 'Paris',
-      position: {lat:48.85661400000001, lng:2.3522219000000177},
-    }
-  },
-  methods: {
-    setPlace (place) {
-      this.place = place
-      this.position = {
-        lat: place.geometry.location.lat(),
-        lng: place.geometry.location.lng(),
-      }
-    },
-  },
-}
+<script lang="coffee">
+export default
+  data: ->
+    return
+      description: 'Paris'
+      position:
+        lat: 48.85661400000001
+        lng: 2.3522219000000177
+
+  methods:
+    setPlace: (place) ->
+      @place = place
+      @position =
+        lat: place.geometry.location.lat()
+        lng: place.geometry.location.lng()
 </script>
 
 <style lang="stylus" scoped>


### PR DESCRIPTION
### Don’t merge this in before merging https://github.com/meteor-vue/vue-meteor/pull/244.

This refactors `GoogleMap.vue`’s script block to be in CoffeeScript, to provide an example of CoffeeScript usage for a component. Since this repo is essentially the test suite for the vue-* packages, I’d like there to be at least one `<script lang="coffee">` component script block in here. That way, something visibly breaks in this demo app if some future update breaks `vue-coffee` or `vue-component`’s compatibility with it (like https://github.com/meteor-vue/vue-meteor/issues/165).