### PR TITLE
Add graphql and graphql-tag dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3,11 +3,6 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
-    "@types/graphql": {
-      "version": "https://registry.npmjs.org/@types/graphql/-/graphql-0.10.2.tgz",
-      "integrity": "sha1-18eay6oXRTtmgcgMNLOPyxDEwIw=",
-      "optional": true
-    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -30,26 +25,103 @@
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "apollo-client": {
-      "version": "https://registry.npmjs.org/apollo-client/-/apollo-client-1.9.3.tgz",
-      "integrity": "sha1-NwALPIAfRXG3sIlznmlqFYiWrqs=",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-1.9.3.tgz",
+      "integrity": "sha512-JABKKbqvcw8DJm3YUkEmyx1SK74i+/DesEtAtyocJi10LLmeMQYQFpg8W3BG1tZsYEQ3owEmPbsdNGTly+VOQg==",
       "requires": {
-        "@types/graphql": "https://registry.npmjs.org/@types/graphql/-/graphql-0.10.2.tgz",
-        "apollo-link-core": "https://registry.npmjs.org/apollo-link-core/-/apollo-link-core-0.5.4.tgz",
-        "graphql": "https://registry.npmjs.org/graphql/-/graphql-0.10.5.tgz",
-        "graphql-anywhere": "https://registry.npmjs.org/graphql-anywhere/-/graphql-anywhere-3.1.0.tgz",
-        "graphql-tag": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.4.2.tgz",
-        "redux": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
-        "symbol-observable": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz",
-        "whatwg-fetch": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz"
-      }
-    },
-    "apollo-link-core": {
-      "version": "https://registry.npmjs.org/apollo-link-core/-/apollo-link-core-0.5.4.tgz",
-      "integrity": "sha1-jv1M10eVmHKjLzE/DM/Cp2s5Zmg=",
-      "requires": {
-        "graphql": "https://registry.npmjs.org/graphql/-/graphql-0.10.5.tgz",
-        "graphql-tag": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.4.2.tgz",
-        "zen-observable-ts": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.4.4.tgz"
+        "@types/graphql": "0.10.2",
+        "apollo-link-core": "0.5.4",
+        "graphql": "0.10.5",
+        "graphql-anywhere": "3.1.0",
+        "graphql-tag": "2.6.0",
+        "redux": "3.7.2",
+        "symbol-observable": "1.1.0",
+        "whatwg-fetch": "2.0.3"
+      },
+      "dependencies": {
+        "@types/graphql": {
+          "version": "0.10.2",
+          "resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-0.10.2.tgz",
+          "integrity": "sha512-Ayw0w+kr8vYd8DToiMXjcHxXv1ljWbqX2mnLwXDxkBgog3vywGriC0JZ+npsuohKs3+E88M8OOtobo4g0X3SIA==",
+          "optional": true
+        },
+        "apollo-link-core": {
+          "version": "0.5.4",
+          "resolved": "https://registry.npmjs.org/apollo-link-core/-/apollo-link-core-0.5.4.tgz",
+          "integrity": "sha512-OxL0Kjizb0eS2ObldDqJEs/tFN9xI9RZuTJcaszgGy+xudoPXhIMCHMr7hGZhy0mK+U+BbBULZJw4YQU4J0ODQ==",
+          "requires": {
+            "graphql": "0.10.5",
+            "graphql-tag": "2.6.0",
+            "zen-observable-ts": "0.4.4"
+          }
+        },
+        "graphql": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/graphql/-/graphql-0.10.5.tgz",
+          "integrity": "sha512-Q7cx22DiLhwHsEfUnUip1Ww/Vfx7FS0w6+iHItNuN61+XpegHSa3k5U0+6M5BcpavQImBwFiy0z3uYwY7cXMLQ==",
+          "requires": {
+            "iterall": "1.1.3"
+          }
+        },
+        "graphql-anywhere": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/graphql-anywhere/-/graphql-anywhere-3.1.0.tgz",
+          "integrity": "sha1-PqDY6GRrXO5oA1AWqadVfBXCHpY="
+        },
+        "graphql-tag": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.6.0.tgz",
+          "integrity": "sha1-D7G59tZlEmPEejQg6CeRDm/tOVI="
+        },
+        "iterall": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.1.3.tgz",
+          "integrity": "sha512-Cu/kb+4HiNSejAPhSaN1VukdNTTi/r4/e+yykqjlG/IW+1gZH5b4+Bq3whDX4tvbYugta3r8KTMUiqT3fIGxuQ=="
+        },
+        "js-tokens": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+        },
+        "lodash-es": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.4.tgz",
+          "integrity": "sha1-3MHXVS4VCgZABzupyzHXDwMpUOc="
+        },
+        "loose-envify": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+          "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+          "requires": {
+            "js-tokens": "3.0.2"
+          }
+        },
+        "redux": {
+          "version": "3.7.2",
+          "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
+          "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+          "requires": {
+            "lodash": "4.17.4",
+            "lodash-es": "4.17.4",
+            "loose-envify": "1.3.1",
+            "symbol-observable": "1.1.0"
+          }
+        },
+        "symbol-observable": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.1.0.tgz",
+          "integrity": "sha512-dQoid9tqQ+uotGhuTKEY11X4xhyYePVnqGSoSm3OGKh2E8LZ6RPULp1uXTctk33IeERlrRJYoVSBglsL05F5Uw=="
+        },
+        "whatwg-fetch": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+          "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+        },
+        "zen-observable-ts": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.4.4.tgz",
+          "integrity": "sha512-SNVY1sWWhoe7FwFmHpD9ERi+7Mhhj3+JdS0BGy2UxLIg7cY+3zQbyZauQCI6DN6YK4uoKNaIm3S7Qkqi1Lr+Fw=="
+        }
       }
     },
     "aproba": {
@@ -98,24 +170,47 @@
       "dev": true
     },
     "babel-plugin-syntax-jsx": {
-      "version": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
       "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
       "dev": true
     },
     "babel-plugin-transform-vue-jsx": {
-      "version": "https://registry.npmjs.org/babel-plugin-transform-vue-jsx/-/babel-plugin-transform-vue-jsx-3.5.0.tgz",
-      "integrity": "sha1-axrSk1GtdTkZQDZ18L+LKkPhdnE=",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-vue-jsx/-/babel-plugin-transform-vue-jsx-3.5.0.tgz",
+      "integrity": "sha512-5vCg8K7aiiLwrFJ45ZF/b4cIiFpGAoYL5uNZpbgiZFptBc5LkueBCQXTVexrd1IFlpTV7XndqFjtWjcJ54JGUQ==",
       "dev": true,
       "requires": {
-        "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+        "esutils": "2.0.2"
+      },
+      "dependencies": {
+        "esutils": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+          "dev": true
+        }
       }
     },
     "babel-runtime": {
-      "version": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "requires": {
-        "core-js": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-        "regenerator-runtime": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz"
+        "core-js": "2.5.1",
+        "regenerator-runtime": "0.11.1"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+        },
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+        }
       }
     },
     "balanced-match": {
@@ -199,10 +294,6 @@
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
     },
-    "core-js": {
-      "version": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-      "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
-    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -265,18 +356,6 @@
       "requires": {
         "jsbn": "0.1.1"
       }
-    },
-    "encoding": {
-      "version": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "requires": {
-        "iconv-lite": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz"
-      }
-    },
-    "esutils": {
-      "version": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-      "dev": true
     },
     "extend": {
       "version": "3.0.1",
@@ -381,19 +460,17 @@
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "graphql": {
-      "version": "https://registry.npmjs.org/graphql/-/graphql-0.10.5.tgz",
-      "integrity": "sha1-yb4Xyivf29E0B3/9m7qki4vs0pg=",
+      "version": "0.11.7",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-0.11.7.tgz",
+      "integrity": "sha512-x7uDjyz8Jx+QPbpCFCMQ8lltnQa4p4vSYHx6ADe8rVYRTdsyhCJbvSty5DAsLVmU6cGakl+r8HQYolKHxk/tiw==",
       "requires": {
-        "iterall": "https://registry.npmjs.org/iterall/-/iterall-1.1.3.tgz"
+        "iterall": "1.1.3"
       }
     },
-    "graphql-anywhere": {
-      "version": "https://registry.npmjs.org/graphql-anywhere/-/graphql-anywhere-3.1.0.tgz",
-      "integrity": "sha1-PqDY6GRrXO5oA1AWqadVfBXCHpY="
-    },
     "graphql-tag": {
-      "version": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.4.2.tgz",
-      "integrity": "sha1-amMpfYUi0DorctJvGyOaqzQ4QM0="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.6.0.tgz",
+      "integrity": "sha1-D7G59tZlEmPEejQg6CeRDm/tOVI="
     },
     "har-schema": {
       "version": "2.0.0",
@@ -440,10 +517,6 @@
         "sshpk": "1.13.1"
       }
     },
-    "iconv-lite": {
-      "version": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha1-90aPYBNfXl2tM5nAqBvpoWA6CCs="
-    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -476,10 +549,6 @@
         "number-is-nan": "1.0.1"
       }
     },
-    "is-stream": {
-      "version": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-    },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
@@ -491,11 +560,46 @@
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isomorphic-fetch": {
-      "version": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "requires": {
-        "node-fetch": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-        "whatwg-fetch": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz"
+        "node-fetch": "1.7.3",
+        "whatwg-fetch": "2.0.3"
+      },
+      "dependencies": {
+        "encoding": {
+          "version": "0.1.12",
+          "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+          "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+          "requires": {
+            "iconv-lite": "0.4.19"
+          }
+        },
+        "iconv-lite": {
+          "version": "0.4.19",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+          "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+        },
+        "node-fetch": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+          "requires": {
+            "encoding": "0.1.12",
+            "is-stream": "1.1.0"
+          }
+        },
+        "whatwg-fetch": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+          "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+        }
       }
     },
     "isstream": {
@@ -504,12 +608,9 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "iterall": {
-      "version": "https://registry.npmjs.org/iterall/-/iterall-1.1.3.tgz",
-      "integrity": "sha1-HLv/liBAVt3mZW4u0uIibQ5tcsk="
-    },
-    "js-tokens": {
-      "version": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.1.3.tgz",
+      "integrity": "sha512-Cu/kb+4HiNSejAPhSaN1VukdNTTi/r4/e+yykqjlG/IW+1gZH5b4+Bq3whDX4tvbYugta3r8KTMUiqT3fIGxuQ=="
     },
     "jsbn": {
       "version": "0.1.1",
@@ -544,601 +645,668 @@
       }
     },
     "lodash": {
-      "version": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
       "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
-    "lodash-es": {
-      "version": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.4.tgz",
-      "integrity": "sha1-3MHXVS4VCgZABzupyzHXDwMpUOc="
-    },
-    "lodash.debounce": {
-      "version": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
-    },
-    "lodash.omit": {
-      "version": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
-      "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA="
-    },
-    "lodash.throttle": {
-      "version": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
-      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
-    },
-    "loose-envify": {
-      "version": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-      "requires": {
-        "js-tokens": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-      }
-    },
     "marker-clusterer-plus": {
-      "version": "https://registry.npmjs.org/marker-clusterer-plus/-/marker-clusterer-plus-2.1.4.tgz",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/marker-clusterer-plus/-/marker-clusterer-plus-2.1.4.tgz",
       "integrity": "sha1-+O/3TVmdqzt9Dj/tUmTqDnBPXWc="
     },
     "meteor-node-stubs": {
-      "version": "https://registry.npmjs.org/meteor-node-stubs/-/meteor-node-stubs-0.3.2.tgz",
-      "integrity": "sha1-LJIkqRGx5mwUHGoXsaPcktw4d5U=",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/meteor-node-stubs/-/meteor-node-stubs-0.3.2.tgz",
+      "integrity": "sha512-l93SS/HutbqBRJODO2m7hup8cYI2acF5bB39+ZvP2BX8HMmCSCXeFH7v0sr4hD7zrVvHQA5UqS0pcDYKn0VM6g==",
       "requires": {
-        "assert": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
-        "browserify-zlib": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
-        "buffer": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
-        "console-browserify": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
-        "constants-browserify": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
-        "crypto-browserify": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.1.tgz",
-        "domain-browser": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
-        "events": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-        "http-browserify": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
-        "https-browserify": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
-        "os-browserify": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.2.1.tgz",
-        "path-browserify": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
-        "process": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-        "punycode": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-        "querystring-es3": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+        "assert": "1.4.1",
+        "browserify-zlib": "0.1.4",
+        "buffer": "4.9.1",
+        "console-browserify": "1.1.0",
+        "constants-browserify": "1.0.0",
+        "crypto-browserify": "3.11.1",
+        "domain-browser": "1.1.7",
+        "events": "1.1.1",
+        "http-browserify": "1.7.0",
+        "https-browserify": "0.0.1",
+        "os-browserify": "0.2.1",
+        "path-browserify": "0.0.0",
+        "process": "0.11.10",
+        "punycode": "1.4.1",
+        "querystring-es3": "0.2.1",
         "readable-stream": "git+https://github.com/meteor/readable-stream.git#d64a64aa6061b9b6855feff4d09e58fb3b2e4502",
-        "stream-browserify": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
-        "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-        "timers-browserify": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
-        "tty-browserify": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
-        "url": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
-        "util": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-        "vm-browserify": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz"
+        "stream-browserify": "2.0.1",
+        "string_decoder": "1.0.3",
+        "timers-browserify": "1.4.2",
+        "tty-browserify": "0.0.0",
+        "url": "0.11.0",
+        "util": "0.10.3",
+        "vm-browserify": "0.0.4"
       },
       "dependencies": {
         "Base64": {
-          "version": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
           "integrity": "sha1-ujpCMHCOGGcFBl5mur3Uw1z2ACg="
         },
         "asn1.js": {
-          "version": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
+          "version": "4.9.1",
+          "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
           "integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA=",
           "requires": {
-            "bn.js": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-            "minimalistic-assert": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
+            "bn.js": "4.11.8",
+            "inherits": "2.0.1",
+            "minimalistic-assert": "1.0.0"
           }
         },
         "assert": {
-          "version": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
           "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
           "requires": {
-            "util": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
+            "util": "0.10.3"
           }
         },
         "balanced-match": {
-          "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "base64-js": {
-          "version": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
           "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw=="
         },
         "bn.js": {
-          "version": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
           "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
         },
         "brace-expansion": {
-          "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+          "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
           "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
           "requires": {
-            "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-            "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
           }
         },
         "brorand": {
-          "version": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
           "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
         },
         "browserify-aes": {
-          "version": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.1.0.tgz",
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.1.0.tgz",
           "integrity": "sha512-W2bIMLYoZ9oow7TyePpMJk9l9LY7O3R61a/68bVCDOtnJynnwe3ZeW2IzzSkrQnPKNdJrxVDn3ALZNisSBwb7g==",
           "requires": {
-            "buffer-xor": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-            "cipher-base": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-            "create-hash": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
-            "evp_bytestokey": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-            "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+            "buffer-xor": "1.0.3",
+            "cipher-base": "1.0.4",
+            "create-hash": "1.1.3",
+            "evp_bytestokey": "1.0.3",
+            "inherits": "2.0.1",
+            "safe-buffer": "5.1.1"
           }
         },
         "browserify-cipher": {
-          "version": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
           "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
           "requires": {
-            "browserify-aes": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.1.0.tgz",
-            "browserify-des": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
-            "evp_bytestokey": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz"
+            "browserify-aes": "1.1.0",
+            "browserify-des": "1.0.0",
+            "evp_bytestokey": "1.0.3"
           }
         },
         "browserify-des": {
-          "version": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
           "integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
           "requires": {
-            "cipher-base": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-            "des.js": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            "cipher-base": "1.0.4",
+            "des.js": "1.0.0",
+            "inherits": "2.0.1"
           }
         },
         "browserify-rsa": {
-          "version": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
           "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
           "requires": {
-            "bn.js": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-            "randombytes": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz"
+            "bn.js": "4.11.8",
+            "randombytes": "2.0.5"
           }
         },
         "browserify-sign": {
-          "version": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
           "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
           "requires": {
-            "bn.js": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-            "browserify-rsa": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
-            "create-hash": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
-            "create-hmac": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
-            "elliptic": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-            "parse-asn1": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz"
+            "bn.js": "4.11.8",
+            "browserify-rsa": "4.0.1",
+            "create-hash": "1.1.3",
+            "create-hmac": "1.1.6",
+            "elliptic": "6.4.0",
+            "inherits": "2.0.1",
+            "parse-asn1": "5.1.0"
           }
         },
         "browserify-zlib": {
-          "version": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
           "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
           "requires": {
-            "pako": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz"
+            "pako": "0.2.9"
           }
         },
         "buffer": {
-          "version": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+          "version": "4.9.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
           "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
           "requires": {
-            "base64-js": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
-            "ieee754": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
-            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+            "base64-js": "1.2.1",
+            "ieee754": "1.1.8",
+            "isarray": "1.0.0"
           }
         },
         "buffer-xor": {
-          "version": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
           "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
         },
         "cipher-base": {
-          "version": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
           "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
           "requires": {
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-            "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+            "inherits": "2.0.1",
+            "safe-buffer": "5.1.1"
           }
         },
         "concat-map": {
-          "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "console-browserify": {
-          "version": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
           "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
           "requires": {
-            "date-now": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
+            "date-now": "0.1.4"
           }
         },
         "constants-browserify": {
-          "version": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
           "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U="
         },
         "create-ecdh": {
-          "version": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
           "integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
           "requires": {
-            "bn.js": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-            "elliptic": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz"
+            "bn.js": "4.11.8",
+            "elliptic": "6.4.0"
           }
         },
         "create-hash": {
-          "version": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
           "integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
           "requires": {
-            "cipher-base": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-            "ripemd160": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
-            "sha.js": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.9.tgz"
+            "cipher-base": "1.0.4",
+            "inherits": "2.0.1",
+            "ripemd160": "2.0.1",
+            "sha.js": "2.4.9"
           }
         },
         "create-hmac": {
-          "version": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
           "integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
           "requires": {
-            "cipher-base": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-            "create-hash": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-            "ripemd160": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
-            "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-            "sha.js": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.9.tgz"
+            "cipher-base": "1.0.4",
+            "create-hash": "1.1.3",
+            "inherits": "2.0.1",
+            "ripemd160": "2.0.1",
+            "safe-buffer": "5.1.1",
+            "sha.js": "2.4.9"
           }
         },
         "crypto-browserify": {
-          "version": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.1.tgz",
+          "version": "3.11.1",
+          "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.1.tgz",
           "integrity": "sha512-Na7ZlwCOqoaW5RwUK1WpXws2kv8mNhWdTlzob0UXulk6G9BDbyiJaGTYBIX61Ozn9l1EPPJpICZb4DaOpT9NlQ==",
           "requires": {
-            "browserify-cipher": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
-            "browserify-sign": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
-            "create-ecdh": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
-            "create-hash": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
-            "create-hmac": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
-            "diffie-hellman": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-            "pbkdf2": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.14.tgz",
-            "public-encrypt": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
-            "randombytes": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz"
+            "browserify-cipher": "1.0.0",
+            "browserify-sign": "4.0.4",
+            "create-ecdh": "4.0.0",
+            "create-hash": "1.1.3",
+            "create-hmac": "1.1.6",
+            "diffie-hellman": "5.0.2",
+            "inherits": "2.0.1",
+            "pbkdf2": "3.0.14",
+            "public-encrypt": "4.0.0",
+            "randombytes": "2.0.5"
           }
         },
         "date-now": {
-          "version": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
           "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
         },
         "des.js": {
-          "version": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
           "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
           "requires": {
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-            "minimalistic-assert": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
+            "inherits": "2.0.1",
+            "minimalistic-assert": "1.0.0"
           }
         },
         "diffie-hellman": {
-          "version": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
           "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
           "requires": {
-            "bn.js": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-            "miller-rabin": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
-            "randombytes": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz"
+            "bn.js": "4.11.8",
+            "miller-rabin": "4.0.1",
+            "randombytes": "2.0.5"
           }
         },
         "domain-browser": {
-          "version": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
           "integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw="
         },
         "elliptic": {
-          "version": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
           "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
           "requires": {
-            "bn.js": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-            "brorand": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-            "hash.js": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-            "hmac-drbg": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-            "minimalistic-assert": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
-            "minimalistic-crypto-utils": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz"
+            "bn.js": "4.11.8",
+            "brorand": "1.1.0",
+            "hash.js": "1.1.3",
+            "hmac-drbg": "1.0.1",
+            "inherits": "2.0.1",
+            "minimalistic-assert": "1.0.0",
+            "minimalistic-crypto-utils": "1.0.1"
           }
         },
         "events": {
-          "version": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
           "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
         },
         "evp_bytestokey": {
-          "version": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
           "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
           "requires": {
-            "md5.js": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
-            "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+            "md5.js": "1.3.4",
+            "safe-buffer": "5.1.1"
           }
         },
         "fs.realpath": {
-          "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "glob": {
-          "version": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "requires": {
-            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.1",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "hash-base": {
-          "version": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
           "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
           "requires": {
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            "inherits": "2.0.1"
           }
         },
         "hash.js": {
-          "version": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
           "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
           "requires": {
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "minimalistic-assert": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
+            "inherits": "2.0.3",
+            "minimalistic-assert": "1.0.0"
           },
           "dependencies": {
             "inherits": {
-              "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "version": "2.0.3",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
               "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
             }
           }
         },
         "hmac-drbg": {
-          "version": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
           "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
           "requires": {
-            "hash.js": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-            "minimalistic-assert": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
-            "minimalistic-crypto-utils": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz"
+            "hash.js": "1.1.3",
+            "minimalistic-assert": "1.0.0",
+            "minimalistic-crypto-utils": "1.0.1"
           }
         },
         "http-browserify": {
-          "version": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
           "integrity": "sha1-M3la3nLfiKz7/TZ3PO/tp2RzWyA=",
           "requires": {
-            "Base64": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            "Base64": "0.2.1",
+            "inherits": "2.0.1"
           }
         },
         "https-browserify": {
-          "version": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
           "integrity": "sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI="
         },
         "ieee754": {
-          "version": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+          "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
           "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
         },
         "indexof": {
-          "version": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
           "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
         },
         "inflight": {
-          "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "requires": {
-            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
-          "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
           "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
         },
         "isarray": {
-          "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "md5.js": {
-          "version": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
           "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
           "requires": {
-            "hash-base": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            "hash-base": "3.0.4",
+            "inherits": "2.0.1"
           },
           "dependencies": {
             "hash-base": {
-              "version": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+              "version": "3.0.4",
+              "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
               "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
               "requires": {
-                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+                "inherits": "2.0.1",
+                "safe-buffer": "5.1.1"
               }
             }
           }
         },
         "miller-rabin": {
-          "version": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
           "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
           "requires": {
-            "bn.js": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-            "brorand": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz"
+            "bn.js": "4.11.8",
+            "brorand": "1.1.0"
           }
         },
         "minimalistic-assert": {
-          "version": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
           "integrity": "sha1-cCvi3aazf0g2vLP121ZkG2Sh09M="
         },
         "minimalistic-crypto-utils": {
-          "version": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
           "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
         },
         "minimatch": {
-          "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
-            "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz"
+            "brace-expansion": "1.1.8"
           }
         },
         "once": {
-          "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "requires": {
-            "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+            "wrappy": "1.0.2"
           }
         },
         "os-browserify": {
-          "version": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.2.1.tgz",
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.2.1.tgz",
           "integrity": "sha1-Y/xMzuXS13Y9Jrv4YBB45sLgBE8="
         },
         "pako": {
-          "version": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+          "version": "0.2.9",
+          "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
           "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
         },
         "parse-asn1": {
-          "version": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
           "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
           "requires": {
-            "asn1.js": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
-            "browserify-aes": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.1.0.tgz",
-            "create-hash": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
-            "evp_bytestokey": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
-            "pbkdf2": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.14.tgz"
+            "asn1.js": "4.9.1",
+            "browserify-aes": "1.1.0",
+            "create-hash": "1.1.3",
+            "evp_bytestokey": "1.0.3",
+            "pbkdf2": "3.0.14"
           }
         },
         "path-browserify": {
-          "version": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+          "version": "0.0.0",
+          "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
           "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo="
         },
         "path-is-absolute": {
-          "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
         },
         "pbkdf2": {
-          "version": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.14.tgz",
+          "version": "3.0.14",
+          "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.14.tgz",
           "integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
           "requires": {
-            "create-hash": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
-            "create-hmac": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
-            "ripemd160": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
-            "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-            "sha.js": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.9.tgz"
+            "create-hash": "1.1.3",
+            "create-hmac": "1.1.6",
+            "ripemd160": "2.0.1",
+            "safe-buffer": "5.1.1",
+            "sha.js": "2.4.9"
           }
         },
         "process": {
-          "version": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+          "version": "0.11.10",
+          "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
           "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
         },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+        },
         "public-encrypt": {
-          "version": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
           "integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
           "requires": {
-            "bn.js": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-            "browserify-rsa": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
-            "create-hash": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
-            "parse-asn1": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
-            "randombytes": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz"
+            "bn.js": "4.11.8",
+            "browserify-rsa": "4.0.1",
+            "create-hash": "1.1.3",
+            "parse-asn1": "5.1.0",
+            "randombytes": "2.0.5"
           }
         },
         "punycode": {
-          "version": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
         },
         "querystring": {
-          "version": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
           "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
         },
         "querystring-es3": {
-          "version": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
           "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
         },
         "randombytes": {
-          "version": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
           "integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
           "requires": {
-            "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+            "safe-buffer": "5.1.1"
           }
         },
         "readable-stream": {
           "version": "git+https://github.com/meteor/readable-stream.git#d64a64aa6061b9b6855feff4d09e58fb3b2e4502",
           "requires": {
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-            "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           },
           "dependencies": {
             "inherits": {
-              "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "version": "2.0.3",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
               "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
             }
           }
         },
         "rimraf": {
-          "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-          "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "requires": {
-            "glob": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz"
+            "glob": "7.1.2"
           }
         },
         "ripemd160": {
-          "version": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
           "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
           "requires": {
-            "hash-base": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            "hash-base": "2.0.2",
+            "inherits": "2.0.1"
           }
         },
         "safe-buffer": {
-          "version": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
         },
         "sha.js": {
-          "version": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.9.tgz",
+          "version": "2.4.9",
+          "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.9.tgz",
           "integrity": "sha512-G8zektVqbiPHrylgew9Zg1VRB1L/DtXNUVAM6q4QLy8NE3qtHlFXTf8VLL4k1Yl6c7NMjtZUTdXV+X44nFaT6A==",
           "requires": {
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-            "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+            "inherits": "2.0.1",
+            "safe-buffer": "5.1.1"
           }
         },
         "stream-browserify": {
-          "version": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
           "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
           "requires": {
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+            "inherits": "2.0.1",
             "readable-stream": "git+https://github.com/meteor/readable-stream.git#d64a64aa6061b9b6855feff4d09e58fb3b2e4502"
           }
         },
         "string_decoder": {
-          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "requires": {
-            "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+            "safe-buffer": "5.1.1"
           }
         },
         "timers-browserify": {
-          "version": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
+          "version": "1.4.2",
+          "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
           "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
           "requires": {
-            "process": "https://registry.npmjs.org/process/-/process-0.11.10.tgz"
+            "process": "0.11.10"
           }
         },
         "tty-browserify": {
-          "version": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+          "version": "0.0.0",
+          "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
           "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY="
         },
         "url": {
-          "version": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
           "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
           "requires": {
-            "punycode": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-            "querystring": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
+            "punycode": "1.3.2",
+            "querystring": "0.2.0"
           },
           "dependencies": {
             "punycode": {
-              "version": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+              "version": "1.3.2",
+              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
               "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
             }
           }
         },
         "util": {
-          "version": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "version": "0.10.3",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "requires": {
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            "inherits": "2.0.1"
           }
         },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+        },
         "vm-browserify": {
-          "version": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+          "version": "0.0.4",
+          "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
           "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
           "requires": {
-            "indexof": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+            "indexof": "0.0.1"
           }
         },
         "wrappy": {
-          "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         }
       }
@@ -1191,14 +1359,6 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
       "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U="
-    },
-    "node-fetch": {
-      "version": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha1-mA9vcthSEaU0fGsrwYxbhMPrR+8=",
-      "requires": {
-        "encoding": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-        "is-stream": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
-      }
     },
     "node-pre-gyp": {
       "version": "0.6.36",
@@ -1334,20 +1494,6 @@
         "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
       }
     },
-    "redux": {
-      "version": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
-      "integrity": "sha1-BrcxIyFZAdJdBlvjQusCa8HIU3s=",
-      "requires": {
-        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-        "lodash-es": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.4.tgz",
-        "loose-envify": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-        "symbol-observable": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz"
-      }
-    },
-    "regenerator-runtime": {
-      "version": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-      "integrity": "sha1-flT+W1zNXWYk6mJVw0c74JC4AuE="
-    },
     "request": {
       "version": "2.83.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
@@ -1464,10 +1610,6 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
-    "symbol-observable": {
-      "version": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz",
-      "integrity": "sha1-Kb9hXUqnEhvdiYsi1LP5vE4qoD0="
-    },
     "tar": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
@@ -1545,43 +1687,76 @@
       "integrity": "sha512-aY26SGDHJTCKM+mndzuiQ0dozPpNeWO5Mtq760OrHO0AOiqVHMhzvU5h0LdCkVF9A+vE+DMTm74xSi+sxnMEDg=="
     },
     "vue-apollo": {
-      "version": "https://registry.npmjs.org/vue-apollo/-/vue-apollo-2.1.0-rc.8.tgz",
-      "integrity": "sha1-7rDk1gDLRfVldQ3tbTs6wN+NtvU=",
+      "version": "2.1.0-rc.8",
+      "resolved": "https://registry.npmjs.org/vue-apollo/-/vue-apollo-2.1.0-rc.8.tgz",
+      "integrity": "sha512-f5OzWztFywrhwPNS7N91Sc1BqgSSRrnRnwyRH12gkkctpbi5pj9LBAagXsDOhcXiCr/iUQbKGkGE4Om8+C/OlQ==",
       "requires": {
-        "lodash.debounce": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-        "lodash.omit": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
-        "lodash.throttle": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz"
+        "lodash.debounce": "4.0.8",
+        "lodash.omit": "4.5.0",
+        "lodash.throttle": "4.1.1"
+      },
+      "dependencies": {
+        "lodash.debounce": {
+          "version": "4.0.8",
+          "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+          "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+        },
+        "lodash.omit": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
+          "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA="
+        },
+        "lodash.throttle": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+          "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
+        }
       }
     },
     "vue-googlemaps": {
-      "version": "https://registry.npmjs.org/vue-googlemaps/-/vue-googlemaps-0.0.6.tgz",
-      "integrity": "sha1-gPGPWw9Cz4shGYau+Vc0Uwinnho=",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/vue-googlemaps/-/vue-googlemaps-0.0.6.tgz",
+      "integrity": "sha512-b4whD7oxGPGWJS0HSD7uvCcj/5WueOI1TuN0fj4iv7/Af/LIdNXNEjhFwI2q2ezt1amZt74u6M/tXM1nsc/+hw==",
       "requires": {
-        "vue-observe-visibility": "https://registry.npmjs.org/vue-observe-visibility/-/vue-observe-visibility-0.3.1.tgz",
-        "vue-resize": "https://registry.npmjs.org/vue-resize/-/vue-resize-0.4.2.tgz"
+        "vue-observe-visibility": "0.3.1",
+        "vue-resize": "0.4.3"
+      },
+      "dependencies": {
+        "vue-resize": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/vue-resize/-/vue-resize-0.4.3.tgz",
+          "integrity": "sha512-lFEhenRjvyzer6JylQOPltJhI48Fv2IukdGPpvb5fqK7FUGxiiGinSlAkPPdug5DQemFFysjp+8GqQU10oWouA=="
+        }
       }
     },
     "vue-meteor-tracker": {
-      "version": "https://registry.npmjs.org/vue-meteor-tracker/-/vue-meteor-tracker-1.2.3.tgz",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/vue-meteor-tracker/-/vue-meteor-tracker-1.2.3.tgz",
       "integrity": "sha1-7wiuyVbC+mwjFFuufw8oFIDtsFA=",
       "requires": {
-        "lodash.omit": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz"
+        "lodash.omit": "4.5.0"
+      },
+      "dependencies": {
+        "lodash.omit": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
+          "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA="
+        }
       }
     },
     "vue-observe-visibility": {
-      "version": "https://registry.npmjs.org/vue-observe-visibility/-/vue-observe-visibility-0.3.1.tgz",
-      "integrity": "sha1-58rTeJPaQoWMCGGW2prNsP2FNAs="
-    },
-    "vue-resize": {
-      "version": "https://registry.npmjs.org/vue-resize/-/vue-resize-0.4.2.tgz",
-      "integrity": "sha1-thjMVffmB+f1JoDyFukeOiaoOK8="
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/vue-observe-visibility/-/vue-observe-visibility-0.3.1.tgz",
+      "integrity": "sha512-hrTdlkTiPmjjH+00dIiCsr/bBPNjUljNc9rboeLXMnXUqeom8LKa4l3iLwb3exa9PUUhtp4RrOtsa2eH0NimsQ=="
     },
     "vue-router": {
-      "version": "https://registry.npmjs.org/vue-router/-/vue-router-3.0.1.tgz",
-      "integrity": "sha1-2bBa2cdCC6D2JtZQDWk+YAkswek="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.0.1.tgz",
+      "integrity": "sha512-vLLoY452L+JBpALMP5UHum9+7nzR9PeIBCghU9ZtJ1eWm6ieUI8Zb/DI3MYxH32bxkjzYV1LRjNv4qr8d+uX/w=="
     },
     "vue-supply": {
-      "version": "https://registry.npmjs.org/vue-supply/-/vue-supply-0.3.0.tgz",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/vue-supply/-/vue-supply-0.3.0.tgz",
       "integrity": "sha1-c6u/UTZ+1DGlvOeSx6L44wpU2Zk="
     },
     "vuex": {
@@ -1590,12 +1765,9 @@
       "integrity": "sha512-wLoqz0B7DSZtgbWL1ShIBBCjv22GV5U+vcBFox658g6V0s4wZV9P4YjCNyoHSyIBpj1f29JBoNQIqD82cR4O3w=="
     },
     "vuex-router-sync": {
-      "version": "https://registry.npmjs.org/vuex-router-sync/-/vuex-router-sync-5.0.0.tgz",
-      "integrity": "sha1-GiJcF6Hdni90rwobLGIHLpSSswU="
-    },
-    "whatwg-fetch": {
-      "version": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
-      "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vuex-router-sync/-/vuex-router-sync-5.0.0.tgz",
+      "integrity": "sha512-Mry2sO4kiAG64714X1CFpTA/shUH1DmkZ26DFDtwoM/yyx6OtMrc+MxrU+7vvbNLO9LSpgwkiJ8W+rlmRtsM+w=="
     },
     "wide-align": {
       "version": "1.1.2",
@@ -1609,10 +1781,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-    },
-    "zen-observable-ts": {
-      "version": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.4.4.tgz",
-      "integrity": "sha1-wkTHHq6+95qYXM+YlbyQMHpulxI="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -294,6 +294,11 @@
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
     },
+    "core-js": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+      "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "apollo-client": "~1.9.3",
     "babel-runtime": "~6.26.0",
     "bcrypt": "^1.0.3",
+    "graphql": "^0.11.7",
+    "graphql-tag": "^2.6.0",
     "intersection-observer": "^0.4.3",
     "isomorphic-fetch": "~2.2.1",
     "lodash": "~4.17.4",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "apollo-client": "~1.9.3",
     "babel-runtime": "~6.26.0",
     "bcrypt": "^1.0.3",
+    "core-js": "^2.5.1",
     "graphql": "^0.11.7",
     "graphql-tag": "^2.6.0",
     "intersection-observer": "^0.4.3",


### PR DESCRIPTION
When standing up this app from a clean checkout the `graphql` and `graphql-tags` dependencies were missing.

This is the result of doing `meteor npm i --save graphql graphql-tags`, and the app works after that.

Might I even suggest tossing out `package-lock.json` for a demo app like this? It just creates a lot of garbage for something that doesn't really require strict dependencies.